### PR TITLE
introduces localization-aware networking to the app and refactors locale management for improved clarity and extensibility.

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,15 +87,34 @@ dependencies {
   implementation(libs.androidx.lifecycle.runtime.ktx)
   implementation(libs.androidx.activity.compose)
   implementation(platform(libs.androidx.compose.bom))
+  // compose lifecycle viewmodel
+  implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.4")
   implementation(libs.androidx.compose.ui)
   implementation(libs.androidx.compose.ui.graphics)
   implementation(libs.androidx.compose.ui.tooling.preview)
   implementation(libs.androidx.compose.material3)
+  debugImplementation(libs.androidx.compose.ui.tooling)
+  debugImplementation(libs.androidx.compose.ui.test.manifest)
+
   testImplementation(libs.junit)
   androidTestImplementation(libs.androidx.junit)
   androidTestImplementation(libs.androidx.espresso.core)
   androidTestImplementation(platform(libs.androidx.compose.bom))
   androidTestImplementation(libs.androidx.compose.ui.test.junit4)
-  debugImplementation(libs.androidx.compose.ui.tooling)
-  debugImplementation(libs.androidx.compose.ui.test.manifest)
+
+  // Retrofit
+  val retrofitVersion = "2.11.0"
+  implementation("com.squareup.retrofit2:retrofit:$retrofitVersion")
+  implementation("com.squareup.retrofit2:converter-moshi:$retrofitVersion")
+
+  // Moshi
+  val moshiVersion = "1.15.1"
+  implementation("com.squareup.moshi:moshi:$moshiVersion")
+  implementation("com.squareup.moshi:moshi-kotlin:$moshiVersion")
+
+  // define a BOM and its version
+  implementation(platform("com.squareup.okhttp3:okhttp-bom:4.12.0"))
+  // define any required OkHttp artifacts without version
+  implementation("com.squareup.okhttp3:okhttp")
+  implementation("com.squareup.okhttp3:logging-interceptor")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,16 +12,22 @@ kotlin {
 }
 
 object Locales {
-  val supportedLocales: Set<String> = setOf(
+  val localeFilters = listOf(
     "en",
-    "en-rUS",
-    "vi",
     "vi-rVN",
   )
 
-  val supportedLanguageCodes: String = supportedLocales
-    .mapTo(LinkedHashSet()) { it.substringBefore("-r") }
-    .joinToString(separator = ",", prefix = "\"", postfix = "\"")
+  val supportedLocales: String =
+    localeFilters.joinToString(
+      separator = ",",
+      prefix = "\"",
+      postfix = "\""
+    ) {
+      it.replace(
+        oldValue = "-r",
+        newValue = "-"
+      )
+    }
 }
 
 android {
@@ -44,15 +50,15 @@ android {
       "!composepreference.preference.generated.resources",
     )
     generateLocaleConfig = true
-    localeFilters += Locales.supportedLocales
+    localeFilters += Locales.localeFilters
   }
 
   buildTypes {
     debug {
       buildConfigField(
         type = "String",
-        name = "SUPPORTED_LANGUAGE_CODES",
-        value = Locales.supportedLanguageCodes,
+        name = "SUPPORTED_LOCALES",
+        value = Locales.supportedLocales,
       )
     }
 
@@ -62,8 +68,8 @@ android {
 
       buildConfigField(
         type = "String",
-        name = "SUPPORTED_LANGUAGE_CODES",
-        value = Locales.supportedLanguageCodes,
+        name = "SUPPORTED_LOCALES",
+        value = Locales.supportedLocales,
       )
     }
   }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
     <application
+        android:name=".MyApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/hoc081098/jetpackcomposelocalization/DemoAcceptLanguageHeader.kt
+++ b/app/src/main/java/com/hoc081098/jetpackcomposelocalization/DemoAcceptLanguageHeader.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -31,14 +32,15 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
-sealed interface DemoAcceptLanguageUiState {
+@Immutable
+internal sealed interface DemoAcceptLanguageUiState {
   data object Idle : DemoAcceptLanguageUiState
   data object Loading : DemoAcceptLanguageUiState
   data class Success(val data: Map<String, Any>) : DemoAcceptLanguageUiState
   data class Error(val message: String?) : DemoAcceptLanguageUiState
 }
 
-class DemoAcceptLanguageViewModel : ViewModel() {
+internal class DemoAcceptLanguageViewModel : ViewModel() {
   private val apiService get() = NetworkServiceLocator.apiService
 
   private val _uiState = MutableStateFlow<DemoAcceptLanguageUiState>(DemoAcceptLanguageUiState.Idle)
@@ -69,7 +71,7 @@ class DemoAcceptLanguageViewModel : ViewModel() {
 }
 
 @Composable
-fun DemoAcceptLanguageHeader(
+internal fun DemoAcceptLanguageHeader(
   modifier: Modifier = Modifier,
   viewModel: DemoAcceptLanguageViewModel = viewModel(),
 ) {
@@ -90,9 +92,9 @@ fun DemoAcceptLanguageHeader(
 
     Spacer(modifier = Modifier.height(8.dp))
 
-    when (val s = state) {
+    when (val currentState = state) {
       DemoAcceptLanguageUiState.Idle ->
-        Text("Press GET to call httpbin.org/get")
+        Text(text = "Press GET to call httpbin.org/get")
 
       DemoAcceptLanguageUiState.Loading ->
         Row(
@@ -101,8 +103,8 @@ fun DemoAcceptLanguageHeader(
           verticalAlignment = Alignment.CenterVertically,
         ) {
           CircularProgressIndicator()
-          Spacer(Modifier.width(8.dp))
-          Text("Loading…")
+          Spacer(modifier = Modifier.width(8.dp))
+          Text(text = "Loading…")
         }
 
       is DemoAcceptLanguageUiState.Success -> {
@@ -111,14 +113,14 @@ fun DemoAcceptLanguageHeader(
           horizontalAlignment = Alignment.CenterHorizontally,
           verticalArrangement = Arrangement.spacedBy(4.dp)
         ) {
-          Text("Response success", style = MaterialTheme.typography.titleSmall)
-          Text("Response: ${s.data}")
+          Text(text = "Response success", style = MaterialTheme.typography.titleSmall)
+          Text(text = "Response: ${currentState.data}")
         }
       }
 
       is DemoAcceptLanguageUiState.Error ->
         Text(
-          text = "Error: ${s.message ?: "unknown"}",
+          text = "Error: ${currentState.message ?: "unknown"}",
           color = MaterialTheme.colorScheme.error,
         )
     }

--- a/app/src/main/java/com/hoc081098/jetpackcomposelocalization/DemoAcceptLanguageHeader.kt
+++ b/app/src/main/java/com/hoc081098/jetpackcomposelocalization/DemoAcceptLanguageHeader.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.hoc081098.jetpackcomposelocalization.data.NetworkServiceLocator
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -43,8 +44,11 @@ class DemoAcceptLanguageViewModel : ViewModel() {
   private val _uiState = MutableStateFlow<DemoAcceptLanguageUiState>(DemoAcceptLanguageUiState.Idle)
   val uiState: StateFlow<DemoAcceptLanguageUiState> = _uiState.asStateFlow()
 
+  private var job: Job? = null
+
   fun get() {
-    viewModelScope.launch {
+    job?.cancel()
+    job = viewModelScope.launch {
       _uiState.value = DemoAcceptLanguageUiState.Loading
       try {
         val response = apiService.getLocalizedData()
@@ -59,6 +63,7 @@ class DemoAcceptLanguageViewModel : ViewModel() {
   }
 
   fun reset() {
+    job?.cancel()
     _uiState.value = DemoAcceptLanguageUiState.Idle
   }
 }
@@ -71,14 +76,16 @@ fun DemoAcceptLanguageHeader(
   val state by viewModel.uiState.collectAsStateWithLifecycle()
 
   Column(
-    modifier = modifier.padding(16.dp),
+    modifier = modifier
+      .fillMaxWidth()
+      .padding(16.dp),
     verticalArrangement = Arrangement.spacedBy(8.dp),
     horizontalAlignment = Alignment.CenterHorizontally,
   ) {
 
     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-      Button(onClick = { viewModel.get() }) { Text("GET") }
-      OutlinedButton(onClick = { viewModel.reset() }) { Text("Reset") }
+      Button(onClick = viewModel::get) { Text("GET") }
+      OutlinedButton(onClick = viewModel::reset) { Text("Reset") }
     }
 
     Spacer(modifier = Modifier.height(8.dp))
@@ -91,6 +98,7 @@ fun DemoAcceptLanguageHeader(
         Row(
           modifier = Modifier.fillMaxWidth(),
           horizontalArrangement = Arrangement.Center,
+          verticalAlignment = Alignment.CenterVertically,
         ) {
           CircularProgressIndicator()
           Spacer(Modifier.width(8.dp))

--- a/app/src/main/java/com/hoc081098/jetpackcomposelocalization/DemoAcceptLanguageHeader.kt
+++ b/app/src/main/java/com/hoc081098/jetpackcomposelocalization/DemoAcceptLanguageHeader.kt
@@ -1,6 +1,7 @@
 package com.hoc081098.jetpackcomposelocalization
 
 import android.util.Log
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -80,6 +81,7 @@ internal fun DemoAcceptLanguageHeader(
   Column(
     modifier = modifier
       .fillMaxWidth()
+      .background(MaterialTheme.colorScheme.secondaryContainer)
       .padding(16.dp),
     verticalArrangement = Arrangement.spacedBy(8.dp),
     horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/com/hoc081098/jetpackcomposelocalization/DemoAcceptLanguageHeader.kt
+++ b/app/src/main/java/com/hoc081098/jetpackcomposelocalization/DemoAcceptLanguageHeader.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -15,6 +16,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
@@ -71,6 +73,7 @@ fun DemoAcceptLanguageHeader(
   Column(
     modifier = modifier.padding(16.dp),
     verticalArrangement = Arrangement.spacedBy(8.dp),
+    horizontalAlignment = Alignment.CenterHorizontally,
   ) {
 
     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -85,14 +88,21 @@ fun DemoAcceptLanguageHeader(
         Text("Press GET to call httpbin.org/get")
 
       DemoAcceptLanguageUiState.Loading ->
-        Row {
+        Row(
+          modifier = Modifier.fillMaxWidth(),
+          horizontalArrangement = Arrangement.Center,
+        ) {
           CircularProgressIndicator()
           Spacer(Modifier.width(8.dp))
           Text("Loading…")
         }
 
       is DemoAcceptLanguageUiState.Success -> {
-        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Column(
+          modifier = Modifier.fillMaxWidth(),
+          horizontalAlignment = Alignment.CenterHorizontally,
+          verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
           Text("Response success", style = MaterialTheme.typography.titleSmall)
           Text("Response: ${s.data}")
         }

--- a/app/src/main/java/com/hoc081098/jetpackcomposelocalization/MainActivity.kt
+++ b/app/src/main/java/com/hoc081098/jetpackcomposelocalization/MainActivity.kt
@@ -103,6 +103,7 @@ private fun MainScreen(modifier: Modifier = Modifier) {
             )
           }
           DemoDateTimeFormatter(locale = appLocaleState.currentLocale)
+          DemoAcceptLanguageHeader()
         }
       }
     }

--- a/app/src/main/java/com/hoc081098/jetpackcomposelocalization/MainActivity.kt
+++ b/app/src/main/java/com/hoc081098/jetpackcomposelocalization/MainActivity.kt
@@ -131,12 +131,7 @@ private fun LanguageOption(
       .clickable(onClick = changeLanguage)
       .padding(16.dp),
     text = buildString {
-      append(
-        when (locale) {
-          AppLocaleState.AppLocale.FollowSystem -> stringResource(R.string.follow_system)
-          is AppLocaleState.AppLocale.Language -> remember(locale) { locale.locale.localizedDisplayName }
-        }
-      )
+      append(locale.localizedDisplayName())
       append(if (isCurrent) " (current language)" else "")
     },
     style = if (isCurrent) {

--- a/app/src/main/java/com/hoc081098/jetpackcomposelocalization/MainActivity.kt
+++ b/app/src/main/java/com/hoc081098/jetpackcomposelocalization/MainActivity.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.util.fastForEach
 import androidx.lifecycle.eventFlow
 import androidx.lifecycle.lifecycleScope
 import com.hoc081098.jetpackcomposelocalization.ui.locale.AppLocaleManager
+import com.hoc081098.jetpackcomposelocalization.ui.locale.AppLocaleState
 import com.hoc081098.jetpackcomposelocalization.ui.locale.localizedDisplayName
 import com.hoc081098.jetpackcomposelocalization.ui.text.DateTimeFormatterCache
 import com.hoc081098.jetpackcomposelocalization.ui.theme.JetpackComposeLocalizationTheme
@@ -95,11 +96,11 @@ private fun MainScreen(modifier: Modifier = Modifier) {
             .weight(1f),
           verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-          appLocaleState.supportedLanguages.fastForEach { language ->
+          appLocaleState.supportedLocales.fastForEach { locale ->
             LanguageOption(
-              language = language,
-              isCurrent = appLocaleState.isCurrentLanguage(language),
-              changeLanguage = appLocaleManager::changeLanguage,
+              locale = locale,
+              isCurrent = appLocaleState.isCurrent(locale),
+              changeLanguage = { appLocaleManager.changeLanguage(locale) },
             )
           }
           DemoDateTimeFormatter(locale = appLocaleState.currentLocale)
@@ -112,9 +113,9 @@ private fun MainScreen(modifier: Modifier = Modifier) {
 
 @Composable
 private fun LanguageOption(
-  language: String,
+  locale: AppLocaleState.AppLocale,
   isCurrent: Boolean,
-  changeLanguage: (language: String) -> Unit,
+  changeLanguage: () -> Unit,
   modifier: Modifier = Modifier
 ) {
   Text(
@@ -127,12 +128,14 @@ private fun LanguageOption(
         color = MaterialTheme.colorScheme.outline,
         shape = MaterialTheme.shapes.medium,
       )
-      .clickable(onClick = { changeLanguage(language) })
+      .clickable(onClick = changeLanguage)
       .padding(16.dp),
     text = buildString {
       append(
-        if (language == AppLocaleManager.FOLLOW_SYSTEM) stringResource(R.string.follow_system)
-        else remember(language) { Locale(language).localizedDisplayName }
+        when (locale) {
+          AppLocaleState.AppLocale.FollowSystem -> stringResource(R.string.follow_system)
+          is AppLocaleState.AppLocale.Language -> remember(locale) { locale.locale.localizedDisplayName }
+        }
       )
       append(if (isCurrent) " (current language)" else "")
     },

--- a/app/src/main/java/com/hoc081098/jetpackcomposelocalization/MainActivity.kt
+++ b/app/src/main/java/com/hoc081098/jetpackcomposelocalization/MainActivity.kt
@@ -24,6 +24,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -69,6 +71,10 @@ private fun MainScreen(modifier: Modifier = Modifier) {
   val appLocaleManager = remember { AppLocaleManager() }
   val appLocaleState = appLocaleManager.rememberAppLocaleState()
 
+  SideEffect {
+    Log.d("MainScreen", ">>> MainScreen recomposed with: $appLocaleState")
+  }
+
   Scaffold(
     modifier = modifier,
     topBar = {
@@ -100,11 +106,13 @@ private fun MainScreen(modifier: Modifier = Modifier) {
           verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
           appLocaleState.supportedLocales.fastForEach { locale ->
-            LanguageOption(
-              locale = locale,
-              isCurrent = appLocaleState.isCurrent(locale),
-              changeLanguage = { appLocaleManager.changeLanguage(locale) },
-            )
+            key(locale) {
+              LanguageOption(
+                locale = locale,
+                isCurrent = appLocaleState.isCurrentLanguage(locale),
+                changeLanguage = { appLocaleManager.changeLanguage(locale) },
+              )
+            }
           }
           DemoDateTimeFormatter(locale = appLocaleState.currentLocale)
           Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/hoc081098/jetpackcomposelocalization/MainActivity.kt
+++ b/app/src/main/java/com/hoc081098/jetpackcomposelocalization/MainActivity.kt
@@ -16,6 +16,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -93,7 +95,8 @@ private fun MainScreen(modifier: Modifier = Modifier) {
         Column(
           modifier = Modifier
             .fillMaxWidth()
-            .weight(1f),
+            .weight(1f)
+            .verticalScroll(rememberScrollState()),
           verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
           appLocaleState.supportedLocales.fastForEach { locale ->
@@ -104,6 +107,7 @@ private fun MainScreen(modifier: Modifier = Modifier) {
             )
           }
           DemoDateTimeFormatter(locale = appLocaleState.currentLocale)
+          Spacer(modifier = Modifier.height(8.dp))
           DemoAcceptLanguageHeader()
         }
       }

--- a/app/src/main/java/com/hoc081098/jetpackcomposelocalization/MyApplication.kt
+++ b/app/src/main/java/com/hoc081098/jetpackcomposelocalization/MyApplication.kt
@@ -1,0 +1,11 @@
+package com.hoc081098.jetpackcomposelocalization
+
+import android.app.Application
+import com.hoc081098.jetpackcomposelocalization.data.NetworkServiceLocator
+
+class MyApplication : Application() {
+  override fun onCreate() {
+    super.onCreate()
+    NetworkServiceLocator.init(this)
+  }
+}

--- a/app/src/main/java/com/hoc081098/jetpackcomposelocalization/data/AcceptedLanguageInterceptor.kt
+++ b/app/src/main/java/com/hoc081098/jetpackcomposelocalization/data/AcceptedLanguageInterceptor.kt
@@ -1,8 +1,8 @@
 package com.hoc081098.jetpackcomposelocalization.data
 
+import androidx.core.os.LocaleListCompat
 import okhttp3.Interceptor
 import okhttp3.Response
-import java.util.Locale
 
 /**
  * An OkHttp interceptor that adds the Accept-Language header to HTTP requests.
@@ -13,12 +13,12 @@ import java.util.Locale
  * @param localeProvider A function that provides the current locale.
  *                       This allows the locale to be updated dynamically.
  */
-class AcceptedLanguageInterceptor(
+internal class AcceptedLanguageInterceptor(
   private val localeProvider: LocaleProvider,
 ) : Interceptor {
 
   fun interface LocaleProvider {
-    fun provide(): Locale
+    fun provide(): LocaleListCompat
   }
 
   /**
@@ -28,10 +28,13 @@ class AcceptedLanguageInterceptor(
    * @return The response from the next interceptor or the network.
    */
   override fun intercept(chain: Interceptor.Chain): Response {
-    val locale = localeProvider.provide()
-    val request = chain.request().newBuilder()
-      .addHeader("Accept-Language", locale.toLanguageTag())
+    val locales = localeProvider.provide()
+
+    val request = chain.request()
+      .newBuilder()
+      .addHeader("Accept-Language", locales.toLanguageTags())
       .build()
+
     return chain.proceed(request)
   }
 }

--- a/app/src/main/java/com/hoc081098/jetpackcomposelocalization/data/AcceptedLanguageInterceptor.kt
+++ b/app/src/main/java/com/hoc081098/jetpackcomposelocalization/data/AcceptedLanguageInterceptor.kt
@@ -1,0 +1,37 @@
+package com.hoc081098.jetpackcomposelocalization.data
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.util.Locale
+
+/**
+ * An OkHttp interceptor that adds the Accept-Language header to HTTP requests.
+ *
+ * This interceptor uses the provided locale to set the Accept-Language header,
+ * allowing servers to respond with content in the appropriate language.
+ *
+ * @param localeProvider A function that provides the current locale.
+ *                       This allows the locale to be updated dynamically.
+ */
+class AcceptedLanguageInterceptor(
+  private val localeProvider: LocaleProvider,
+) : Interceptor {
+
+  fun interface LocaleProvider {
+    fun provide(): Locale
+  }
+
+  /**
+   * Intercepts the HTTP request and adds the Accept-Language header.
+   *
+   * @param chain The interceptor chain.
+   * @return The response from the next interceptor or the network.
+   */
+  override fun intercept(chain: Interceptor.Chain): Response {
+    val locale = localeProvider.provide()
+    val request = chain.request().newBuilder()
+      .addHeader("Accept-Language", locale.toLanguageTag())
+      .build()
+    return chain.proceed(request)
+  }
+}

--- a/app/src/main/java/com/hoc081098/jetpackcomposelocalization/data/ApiService.kt
+++ b/app/src/main/java/com/hoc081098/jetpackcomposelocalization/data/ApiService.kt
@@ -1,0 +1,8 @@
+package com.hoc081098.jetpackcomposelocalization.data
+
+import retrofit2.http.GET
+
+interface ApiService {
+  @GET("get")
+  suspend fun getLocalizedData(): Map<String, Any>
+}

--- a/app/src/main/java/com/hoc081098/jetpackcomposelocalization/data/NetworkServiceLocator.kt
+++ b/app/src/main/java/com/hoc081098/jetpackcomposelocalization/data/NetworkServiceLocator.kt
@@ -2,7 +2,6 @@ package com.hoc081098.jetpackcomposelocalization.data
 
 import android.app.Application
 import androidx.core.app.LocaleManagerCompat
-import androidx.core.os.LocaleListCompat
 import com.hoc081098.jetpackcomposelocalization.BuildConfig
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
@@ -34,14 +33,15 @@ object NetworkServiceLocator {
 
   private val localeProvider: AcceptedLanguageInterceptor.LocaleProvider
     get() = AcceptedLanguageInterceptor.LocaleProvider {
-      LocaleManagerCompat.getApplicationLocales(application)[0]
-        ?: LocaleListCompat.getAdjustedDefault()[0]!!
+      LocaleManagerCompat.getApplicationLocales(application)
+        .takeIf { it.size() > 0 }
+        ?: LocaleManagerCompat.getSystemLocales(application)
     }
 
   private val acceptedLanguageInterceptor: AcceptedLanguageInterceptor
     get() = AcceptedLanguageInterceptor(localeProvider)
 
-  val okHttpClient: OkHttpClient by lazy {
+  private val okHttpClient: OkHttpClient by lazy {
     OkHttpClient.Builder()
       .readTimeout(30, TimeUnit.SECONDS)
       .writeTimeout(30, TimeUnit.SECONDS)
@@ -59,7 +59,7 @@ object NetworkServiceLocator {
       .build()
   }
 
-  val retrofit: Retrofit by lazy {
+  private val retrofit: Retrofit by lazy {
     Retrofit.Builder()
       .baseUrl(BASE_URL)
       .client(okHttpClient)

--- a/app/src/main/java/com/hoc081098/jetpackcomposelocalization/data/NetworkServiceLocator.kt
+++ b/app/src/main/java/com/hoc081098/jetpackcomposelocalization/data/NetworkServiceLocator.kt
@@ -1,0 +1,71 @@
+package com.hoc081098.jetpackcomposelocalization.data
+
+import android.app.Application
+import androidx.core.app.LocaleManagerCompat
+import androidx.core.os.LocaleListCompat
+import com.hoc081098.jetpackcomposelocalization.BuildConfig
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.create
+import java.util.concurrent.TimeUnit
+
+object NetworkServiceLocator {
+  private const val BASE_URL = "https://httpbin.org/"
+
+  private var _application: Application? = null
+
+  fun init(app: Application) {
+    _application = app
+  }
+
+  private val application: Application
+    get() = _application
+      ?: throw IllegalStateException("NetworkServiceLocator is not initialized. Call init(app) before using it.")
+
+  private val moshi: Moshi by lazy {
+    Moshi.Builder()
+      .addLast(KotlinJsonAdapterFactory())
+      .build()
+  }
+
+  private val localeProvider: AcceptedLanguageInterceptor.LocaleProvider
+    get() = AcceptedLanguageInterceptor.LocaleProvider {
+      LocaleManagerCompat.getApplicationLocales(application)[0]
+        ?: LocaleListCompat.getAdjustedDefault()[0]!!
+    }
+
+  private val acceptedLanguageInterceptor: AcceptedLanguageInterceptor
+    get() = AcceptedLanguageInterceptor(localeProvider)
+
+  val okHttpClient: OkHttpClient by lazy {
+    OkHttpClient.Builder()
+      .readTimeout(30, TimeUnit.SECONDS)
+      .writeTimeout(30, TimeUnit.SECONDS)
+      .connectTimeout(30, TimeUnit.SECONDS)
+      .addInterceptor(acceptedLanguageInterceptor)
+      .addNetworkInterceptor(
+        HttpLoggingInterceptor().apply {
+          level = if (BuildConfig.DEBUG) {
+            HttpLoggingInterceptor.Level.BODY
+          } else {
+            HttpLoggingInterceptor.Level.NONE
+          }
+        }
+      )
+      .build()
+  }
+
+  val retrofit: Retrofit by lazy {
+    Retrofit.Builder()
+      .baseUrl(BASE_URL)
+      .client(okHttpClient)
+      .addConverterFactory(MoshiConverterFactory.create(moshi))
+      .build()
+  }
+
+  val apiService: ApiService by lazy { retrofit.create() }
+}

--- a/app/src/main/java/com/hoc081098/jetpackcomposelocalization/ui/locale/AppLocaleManager.kt
+++ b/app/src/main/java/com/hoc081098/jetpackcomposelocalization/ui/locale/AppLocaleManager.kt
@@ -1,13 +1,17 @@
 package com.hoc081098.jetpackcomposelocalization.ui.locale
 
 import android.util.Log
+import androidx.activity.compose.LocalActivity
+import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.res.stringResource
 import androidx.core.os.LocaleListCompat
 import com.hoc081098.jetpackcomposelocalization.BuildConfig
+import com.hoc081098.jetpackcomposelocalization.R
 import java.util.Locale
 
 @Immutable
@@ -47,6 +51,8 @@ class AppLocaleManager {
 
   @Composable
   fun rememberAppLocaleState(): AppLocaleState {
+    check(LocalActivity.current is AppCompatActivity) { "Must be called from an AppCompatActivity" }
+
     val locale = currentLocale()
 
     // Set empty locale list to follow system
@@ -64,16 +70,15 @@ class AppLocaleManager {
   fun changeLanguage(locale: AppLocaleState.AppLocale) {
     Log.d(LOG_TAG, ">>> setApplicationLocales: to $locale")
 
-    when (locale) {
-      AppLocaleState.AppLocale.FollowSystem -> {
+    val target = when (locale) {
+      AppLocaleState.AppLocale.FollowSystem ->
         // Set empty locale list to follow system
-        AppCompatDelegate.setApplicationLocales(LocaleListCompat.getEmptyLocaleList())
-      }
+        LocaleListCompat.getEmptyLocaleList()
 
-      is AppLocaleState.AppLocale.Language -> {
-        AppCompatDelegate.setApplicationLocales(LocaleListCompat.create(locale.locale))
-      }
+      is AppLocaleState.AppLocale.Language ->
+        LocaleListCompat.create(locale.locale)
     }
+    AppCompatDelegate.setApplicationLocales(target)
 
     Log.d(LOG_TAG, ">>> getApplicationLocales: ${AppCompatDelegate.getApplicationLocales()}")
   }
@@ -83,9 +88,16 @@ class AppLocaleManager {
   }
 }
 
-val Locale.localizedDisplayName: String
+private val Locale.localizedDisplayName: String
   inline get() = getDisplayName(this)
     .replaceFirstChar {
       if (it.isLowerCase()) it.titlecase(this)
       else it.toString()
     }
+
+@Composable
+fun AppLocaleState.AppLocale.localizedDisplayName(): String =
+  when (this) {
+    AppLocaleState.AppLocale.FollowSystem -> stringResource(R.string.follow_system)
+    is AppLocaleState.AppLocale.Language -> remember(locale) { locale.localizedDisplayName }
+  }

--- a/app/src/main/java/com/hoc081098/jetpackcomposelocalization/ui/locale/AppLocaleManager.kt
+++ b/app/src/main/java/com/hoc081098/jetpackcomposelocalization/ui/locale/AppLocaleManager.kt
@@ -61,6 +61,24 @@ class AppLocaleManager {
     )
   }
 
+  /**
+   * Recomposition trigger tied to application locales.
+   *
+   * Why this exists:
+   * - Calling [AppCompatDelegate.setApplicationLocales] may be a no-op (e.g., target equals current)
+   *   or its effects may not be observable immediately via [currentLocale]/[AppCompatDelegate.getApplicationLocales].
+   * - When that happens, Compose wouldn't naturally recompose, so the UI wouldn't reflect a (potential)
+   *   locale change.
+   *
+   * How it works:
+   * - We read this state in [rememberAppLocaleState] to create a dependency.
+   * - After any [changeLanguage] call, we write to this state using [neverEqualPolicy], which
+   *   always invalidates and forces recomposition regardless of the written value.
+   *
+   * Notes:
+   * - This is not a source of truth for the locale; it's just an invalidation signal.
+   * - Actual locale data still comes from [currentLocale].
+   */
   private val applicationLocalesSignalState = mutableStateOf(
     value = Unit,
     policy = neverEqualPolicy()

--- a/app/src/main/java/com/hoc081098/jetpackcomposelocalization/ui/locale/currentLocale.kt
+++ b/app/src/main/java/com/hoc081098/jetpackcomposelocalization/ui/locale/currentLocale.kt
@@ -1,11 +1,17 @@
 package com.hoc081098.jetpackcomposelocalization.ui.locale
 
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.LocaleManagerCompat
 import androidx.core.os.ConfigurationCompat
 import androidx.core.os.LocaleListCompat
+import com.hoc081098.jetpackcomposelocalization.BuildConfig
 import java.util.Locale
+
+private const val LOG_TAG = "currentLocale"
 
 /**
  * Returns the current effective [Locale] for Compose content.
@@ -18,6 +24,20 @@ import java.util.Locale
  */
 @Composable
 @ReadOnlyComposable
-fun currentLocale(): Locale =
-  ConfigurationCompat.getLocales(LocalConfiguration.current)[0]
+fun currentLocale(): Locale {
+  if (BuildConfig.DEBUG) {
+    // Log the current locales for debugging purposes
+    val localesFromConfig = ConfigurationCompat.getLocales(LocalConfiguration.current).toLanguageTags()
+    val systemLocales = LocaleManagerCompat.getSystemLocales(LocalContext.current).toLanguageTags()
+    val defaultLocales = LocaleListCompat.getAdjustedDefault().toLanguageTags()
+    val default = Locale.getDefault().toLanguageTag()
+
+    Log.d(LOG_TAG, ">>>     currentLocale [1]: LocalConfiguration  = $localesFromConfig")
+    Log.d(LOG_TAG, "    >>> currentLocale [2]: getSystemLocales    = $systemLocales")
+    Log.d(LOG_TAG, "    >>> currentLocale [3]: getAdjustedDefault  = $defaultLocales")
+    Log.d(LOG_TAG, "    >>> currentLocale [4]: Locale.getDefault() = $default")
+  }
+
+  return ConfigurationCompat.getLocales(LocalConfiguration.current)[0]
     ?: LocaleListCompat.getAdjustedDefault()[0]!!
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ androidxAppcompat="1.7.1"
 lifecycleRuntimeKtx = "2.9.4"
 activityCompose = "1.11.0"
 composeBom = "2024.09.00"
+okhttp = "4.12.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -26,9 +27,9 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-


### PR DESCRIPTION
This pull request introduces localization-aware networking to the app and refactors locale management for improved clarity and extensibility. It adds a new demo for showing how the Accept-Language header is sent in network requests, updates dependencies to support networking (Retrofit, Moshi, OkHttp), and refactors locale selection logic to work with full locale objects instead of language strings. The most significant changes are grouped below.

**Localization-aware networking:**

* Added `AcceptedLanguageInterceptor`, `ApiService`, and `NetworkServiceLocator` to inject the current app locale into the `Accept-Language` HTTP header for all outgoing requests using OkHttp and Retrofit. [[1]](diffhunk://#diff-eae3fee6e8e5893ebb32a7c6c9f3fd94c88c9eaeeba845aac3f47770f537966fR1-R37) [[2]](diffhunk://#diff-ff51a271b6eea4b71766cd6cbeb27d898483843300515ca4a1ae4c678f11598bR1-R8) [[3]](diffhunk://#diff-043819b51188f09e63991c5a206070431e1855647d10a961e366c3224088f031R1-R71)
* Updated the manifest to request internet and network state permissions, and registered a custom `MyApplication` class to initialize network services. [[1]](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR4-R8) [[2]](diffhunk://#diff-30c2ac3bc5b495cba8d08b6bdfd56a2dcd0c3ceeff854c452f1750a5459d13d1R1-R11)

**Locale management refactor:**

* Refactored `AppLocaleManager` and related UI to use a sealed `AppLocale` type (with `FollowSystem` and specific `Language` variants), replacing previous language string handling. This improves type safety and extensibility for locale selection. [[1]](diffhunk://#diff-6b08a05d4a461723389b0f605bdcf82202c37fc566b6769a0dc1a2b551e10452R4-R55) [[2]](diffhunk://#diff-6b08a05d4a461723389b0f605bdcf82202c37fc566b6769a0dc1a2b551e10452L53-R103) [[3]](diffhunk://#diff-4619d562e977374ced3e517578a5d4899fb734ab33a4d5dfa926afcf2aa0a497R36) [[4]](diffhunk://#diff-4619d562e977374ced3e517578a5d4899fb734ab33a4d5dfa926afcf2aa0a497L98-R107) [[5]](diffhunk://#diff-4619d562e977374ced3e517578a5d4899fb734ab33a4d5dfa926afcf2aa0a497L114-R118) [[6]](diffhunk://#diff-4619d562e977374ced3e517578a5d4899fb734ab33a4d5dfa926afcf2aa0a497L129-R134)

**Networking demo UI:**

* Added `DemoAcceptLanguageHeader` composable and its view model to demonstrate fetching data from `httpbin.org/get` and displaying the result or errors, showing how the Accept-Language header is used. [[1]](diffhunk://#diff-50d1cbf02d6b145e9c67bbd49b4c25c6ef0f60f28e02efceecc8f0541d02ec16R1-R126) [[2]](diffhunk://#diff-4619d562e977374ced3e517578a5d4899fb734ab33a4d5dfa926afcf2aa0a497L98-R107)

**Build configuration and dependencies:**

* Updated `build.gradle.kts` to add dependencies for Retrofit, Moshi, and OkHttp, and refactored locale configuration to use locale tags instead of language codes. [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L15-R30) [[2]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L47-R61) [[3]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L65-R72) [[4]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R96-R125) [[5]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR12)

**IDE configuration:**

* Added commit message inspection profile to `.idea/vcs.xml` for improved commit quality in development.